### PR TITLE
Typo Fixes in Intro 

### DIFF
--- a/aml-book/contents/lecture1-introduction.ipynb
+++ b/aml-book/contents/lecture1-introduction.ipynb
@@ -604,7 +604,7 @@
     "### Executable Course Materials\n",
     "\n",
     "The core materials for this course (including the slides!) are created using Jupyter notebooks.\n",
-    "* We are going to embed an execute code directly in the slides and use that to demonstrate algorithms.\n",
+    "* We are going to embed and execute code directly in the slides and use that to demonstrate algorithms.\n",
     "* These slides can be downloaded locally and all the code can be reproduced.\n",
     "\n",
     "Below is an example, where use some standard Python ML libraries to solve a digit classification task."

--- a/aml-book/contents/lecture1-introduction.ipynb
+++ b/aml-book/contents/lecture1-introduction.ipynb
@@ -202,7 +202,7 @@
     "object = camera.get_object() # assumes we have a \"camera\" API\n",
     "if object.has_wheels(): # does the object have wheels?\n",
     "    if len(object.wheels) == 4: return \"Car\" # four wheels => car    \n",
-    "    elif len(object.wheels) == 2:,\n",
+    "    elif len(object.wheels) == 2:\n",
     "        if object.seen_from_back():\n",
     "            return \"Car\" # viewed from back, car has 2 wheels\n",
     "        else:\n",


### PR DESCRIPTION
Type of PR: Typo Fixes
NetID: ew447
- In the psuedocode for rule-based classification, I believe there is an extra comma after the elif statement. I understand this is pseudocode so exact correctness isn't necessary, but I think this syntax error could cause some confusion
- In the discussion of executable course materials, I believe "an" is a typo. I think the sentence would make more sense if "an" was switched to "and". If the intent was to have "an" precede a noun phrase, a different grammatically correct sentence could be "We are going to embed executable code directly in the slides and use that to demonstrate algorithms"